### PR TITLE
Resolve Detection Bugs with Browsers

### DIFF
--- a/src/appviewtypes.h
+++ b/src/appviewtypes.h
@@ -197,6 +197,7 @@ typedef struct
 #define DEFAULT_COREDUMP_ENABLE FALSE
 #define DEFAULT_BACKTRACE_ENABLE FALSE
 
+#define DEFAULT_IPC_ENABLE TRUE
 /*
  * This calculation is not what we need in the long run.
  * Not all events are rate limited; only metric events at this point.
@@ -213,7 +214,7 @@ typedef struct
 //    APPVIEW_HOST_WORKDIR_PATH        internal use - informs the attached process in container to create working directory
 //                                   in container mnt namespace, which allows to access data during attach operation initialized from host
 //    APPVIEW_RULES                   "false" disables handling the rules file
-//                                   other values are interpreted a path to a rules file
+//                                     other values are interpreted a path to a rules file
 //    APPVIEW_EXECVE                   "false" disables appview of child procs
 //    APPVIEW_EXEC_PATH                specifies path to appview executable
 //    APPVIEW_CRIBL_NO_BREAKER         adds breaker property to process start message
@@ -231,7 +232,8 @@ typedef struct
 //    APPVIEW_QUEUE_LENGTH             override default circular buffer sizes
 //    APPVIEW_START_NOPROFILE          cause the start command to ignore updates to /etc/profile.d
 //    APPVIEW_START_FORCE_PROFILE      force the start command to update profile.d with a dev version
-//    CRIBL_EDGE_FS_ROOT             define the location of the host root path inside the Cribl Edge container
+//    CRIBL_EDGE_FS_ROOT               define the location of the host root path inside the Cribl Edge container
+//    APPVIEW_IPC_ENABLE               set to true to enable IPC with an appview CLI
 #define APPVIEW_PID_ENV "APPVIEW_PID"
 #define PRESERVE_PERF_REPORTING "APPVIEW_PERF_PRESERVE"
 #define APPVIEW_PAYLOAD_TO_DISK_ENV "APPVIEW_PAYLOAD_TO_DISK"

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -81,13 +81,14 @@ struct _config_t
     // CFG_MTC, CFG_CTL, or CFG_LOG
     transport_struct_t transport[CFG_WHICH_MAX]; 
 
-    custom_tag_t** tags;
+    custom_tag_t **tags;
     unsigned max_tags;
 
-    char* commanddir;
+    char *commanddir;
     unsigned processstartmsg;
     unsigned enhancefs;
     char *authtoken;
+    unsigned ipcEnable;
 };
 
 static const char* valueFilterDefault[] = {
@@ -249,6 +250,7 @@ cfgCreateDefault(void)
     c->snapshot.coredump = DEFAULT_COREDUMP_ENABLE;
     c->snapshot.backtrace = DEFAULT_BACKTRACE_ENABLE;
 
+    c->ipcEnable = DEFAULT_IPC_ENABLE;
     return c;
 }
 
@@ -1073,4 +1075,15 @@ void
 cfgSnapshotBacktraceSet(config_t *cfg, unsigned val) {
     if (!cfg || val > 1) return;
     cfg->snapshot.backtrace = val;
+}
+
+unsigned
+cfgIpcEnable(config_t *cfg) {
+    return (cfg) ? cfg->ipcEnable : DEFAULT_IPC_ENABLE;
+}
+
+void
+cfgIpcEnableSet(config_t *cfg, unsigned val) {
+    if (!cfg || val > 1) return;
+    cfg->ipcEnable = val;
 }

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -55,6 +55,7 @@ regex_t *           cfgEvtFormatHeaderRe(config_t *, int);
 const char *        cfgAuthToken(config_t *);
 unsigned            cfgSnapshotCoredumpEnable(config_t *);
 unsigned            cfgSnapshotBacktraceEnable(config_t *);
+unsigned            cfgIpcEnable(config_t *);
 
 // Setters (modifies config_t, but does not persist modifications)
 void                cfgMtcEnableSet(config_t*, unsigned);
@@ -93,5 +94,5 @@ void                cfgLogStreamCloudSet(config_t *, unsigned);
 void                cfgAuthTokenSet(config_t *, const char *);
 void                cfgSnapshotCoredumpSet(config_t *, unsigned);
 void                cfgSnapshotBacktraceSet(config_t *, unsigned);
-
+void                cfgIpcEnableSet(config_t *, unsigned);
 #endif // __CFG_H__

--- a/src/cfgutils.c
+++ b/src/cfgutils.c
@@ -200,6 +200,7 @@ void cfgEvtFormatHeaderSetFromStr(config_t *, const char *);
 void cfgCriblEnableSetFromStr(config_t *, const char *);
 void cfgSnapShotCoredumpEnableSetFomStr(config_t *, const char *);
 void cfgSnapshotBacktraceEnableSetFomStr(config_t *, const char *);
+void cfgIpcEnableSetFomStr(config_t *, const char *);
 static void cfgSetFromFile(config_t *, const char *);
 
 static void processRoot(config_t *, yaml_document_t *, yaml_node_t *);
@@ -471,7 +472,6 @@ processAttach(const char* value)
 static void
 processEnvStyleInput(config_t *cfg, const char *env_line)
 {
-
     if (!cfg || !env_line) return;
 
     char *env_name = NULL;
@@ -653,6 +653,8 @@ processEnvStyleInput(config_t *cfg, const char *env_line)
         cfgSnapShotCoredumpEnableSetFomStr(cfg, value);
     }  else if (startsWith(env_name, "APPVIEW_SNAPSHOT_BACKTRACE")) {
         cfgSnapshotBacktraceEnableSetFomStr(cfg, value);
+    } else if (!appview_strcmp(env_name, "APPVIEW_IPC_ENABLE")) {
+        cfgIpcEnableSetFomStr(cfg, value);
     }
 
 cleanup:
@@ -992,6 +994,13 @@ cfgSnapshotBacktraceEnableSetFomStr(config_t *cfg, const char *value)
 {
     if (!cfg || !value) return;
     cfgSnapshotBacktraceSet(cfg, strToVal(boolMap, value));
+}
+
+void
+cfgIpcEnableSetFomStr(config_t *cfg, const char *value)
+{
+    if (!cfg || !value) return;
+    cfgIpcEnableSet(cfg, strToVal(boolMap, value));
 }
 
 #ifndef NO_YAML

--- a/src/state.c
+++ b/src/state.c
@@ -1326,18 +1326,15 @@ doDetectFile(const char *path, fs_info *fs, struct stat *sbuf)
 
     // check for spaces at the end of file names
     i = appview_strlen(path);
-    do {
-        if (appview_isspace(path[i])) {
-            char msg[PATH_MAX + 128];
+    if (appview_isspace(path[i])) {
+        char msg[PATH_MAX + 128];
 
-            appview_snprintf(msg, sizeof(msg),
-                           "spaces at the end of the path name %s representing a potential issue",
-                           path);
-            fileSecurity(path, msg, FALSE, 0);
-            notify(NOTIFY_FILES, msg);
-        }
-        i--;
-    }  while (i > 0);
+        appview_snprintf(msg, sizeof(msg),
+                         "spaces at the end of the path name %s representing a potential issue",
+                         path);
+        fileSecurity(path, msg, FALSE, 0);
+        notify(NOTIFY_FILES, msg);
+    }
 
     // check for several file permission settings that could represent potential issues
     // check for files that have the setuid or setgid bits set

--- a/src/state.c
+++ b/src/state.c
@@ -1326,7 +1326,7 @@ doDetectFile(const char *path, fs_info *fs, struct stat *sbuf)
 
     // check for spaces at the end of file names
     i = appview_strlen(path);
-    if (appview_isspace(path[i])) {
+    if (appview_isspace(path[i - 1])) {
         char msg[PATH_MAX + 128];
 
         appview_snprintf(msg, sizeof(msg),

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -502,6 +502,13 @@ ipcCommunication(void) {
     char name[256] = {0};
 
     /*
+     * If IPC is enabled by config continue. It's enabled by default.
+     * Can be disabled with the the env var APPVIEW_IPC_ENABLE = false
+     * Some sandbox envs produce errors if mq system calls are used.
+     */
+    if (cfgIpcEnable(g_staticfg) == FALSE) return;
+
+    /*
     * Handle incoming message queue
     * - check if it exists
     * - check if there are message request on it
@@ -1099,7 +1106,7 @@ handleExit(void)
     g_exitdone = TRUE;
 
     // detect GOT mods
-    //inspectGotTables();
+    inspectGotTables();
 
     if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
 
@@ -2215,6 +2222,8 @@ next:
 static void
 inspectGotTables(void)
 {
+    if (g_notify_def.libs == FALSE) return;
+
     dl_iterate_phdr(inspectLib, NULL);
 }
 

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -1106,7 +1106,7 @@ handleExit(void)
     g_exitdone = TRUE;
 
     // detect GOT mods
-    inspectGotTables();
+    //inspectGotTables();
 
     if (!atomicCasU64(&reentrancy_guard, 0ULL, 1ULL)) {
 

--- a/test/integration/tls/Dockerfile
+++ b/test/integration/tls/Dockerfile
@@ -1,14 +1,11 @@
-FROM centos:7
+FROM quay.io/centos/centos:stream9
 
 RUN yum -y update && \
-    yum -y install centos-release-scl && \
-    yum -y install rh-python38 python-virtualenv && \
-    yum -y install epel-release && \
     yum -y groupinstall 'Development Tools' && \
+    yum -y install python pip && \
+    yum -y install epel-release && \
     yum -y install gnutls-devel openssl-devel wget automake python-pip && \
     yum -y install ruby php httpd mod_ssl && \
-    yum -y --enablerepo=centos-sclo-rh-testing install devtoolset-8-gdb && \
-    source scl_source enable devtoolset-8 && \
     curl -sL https://rpm.nodesource.com/setup_12.x | bash - && \
     yum -y install nodejs
 
@@ -45,8 +42,6 @@ COPY ./tls/ruby/server.rb /opt/test-runner/ruby
 COPY ./tls/ruby/client.rb /opt/test-runner/ruby
 RUN chmod u+x /opt/test-runner/ruby/*rb
 
-RUN /opt/rh/rh-python38/root/usr/bin/python3.8 -m pip install --upgrade pip
-RUN /opt/rh/rh-python38/root/usr/local/bin/pip3.8 install pyopenssl
 COPY ./tls/testssl.py /opt/test-runner/bin/testssl.py
 
 RUN mkdir /opt/test-runner/php
@@ -54,6 +49,12 @@ COPY ./tls/php/sslclient.php /opt/test-runner/php
 
 COPY ./tls/alias /root/.alias
 COPY ./tls/gdbinit /root/.gdbinit
+
+RUN openssl genrsa -out ca.key 2048 && \
+    openssl req -new -key ca.key -out ca.csr -subj "/C=US/ST=California/L=San Francisco/O=Cribl/OU=Cribl/CN=localhost" && \
+    openssl x509 -req -days 3650 -in ca.csr -signkey ca.key -out ca.crt && \
+    cp ca.crt /etc/pki/tls/certs/localhost.crt && \
+    cp ca.key /etc/pki/tls/private/localhost.key
 
 ENV APPVIEW_CRIBL_ENABLE=false
 ENV APPVIEW_LOG_LEVEL=info


### PR DESCRIPTION
- the check for spaces at end of file looks at the entire path and not the end only.

- need an env var to turn off IPC. the use of mq_open (any mq_) causes firefox checks to emit an error. we disable it with a MOZ_ env var.

- we need to check the config var for lib checks. we don't check at all. chrome encounters GOT check errors as chromeOS installs its' own handlers for many (all?) libc functions. we'd want to disable GOT checks in a case like chrome.